### PR TITLE
perf: optimize cloning and minor other changes

### DIFF
--- a/benchmarks/clone.js
+++ b/benchmarks/clone.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const clone = require('../lib/utils').clone;
+const Bench = require('benchmark');
+const mongo = new require('mongodb');
+
+const doc = {
+  first: { second: { third: [3, { name: 'aaron' }, 9] } },
+  comments: [
+    { name: 'one' },
+    { name: 'two', _doc: { name: '2' } },
+    {
+      name: 'three',
+      comments: [{}, { comments: [{ val: 'twoo' }] }],
+      _doc: { name: '3', comments: [{}, { _doc: { comments: [{ val: 2 }] } }] }
+    }
+  ],
+  null: null,
+  date: new Date(),
+  regexp: /objectId/g,
+  name: 'jiro',
+  array: [
+    { o: { array: [{ x: { b: [4, 6, 8] } }, { y: 10 }] } },
+    { o: { array: [{ x: { b: [1, 2, 3] } }, { x: { z: 10 } }, { x: { b: 'hi' } }] } },
+    { o: { array: [{ x: { b: null } }, { x: { b: [null, 1] } }] } },
+    { o: { array: [{ x: null }] } },
+    { o: { array: [{ y: 3 }] } },
+    { o: { array: [3, 0, null] } },
+    { o: { name: 'ha' } }
+  ],
+  arr: [
+    { arr: [{ a: { b: 47 } }, { a: { c: 48 } }, { d: 'yep' }] },
+    { yep: true }
+  ]
+};
+
+function ObjectID(id) {
+  this.id = id;
+  this.cloned = false;
+}
+
+ObjectID.prototype.clone = function() {
+  const ret = new ObjectID(this.id);
+  ret.cloned = true;
+  return ret;
+};
+
+const simple = new Array(100).fill('a');
+const big = new Array(100000).fill('a');
+const complex = new Array(100).fill(doc);
+const date = new Date();
+const objId = new ObjectID('12341234123');
+const buffer = Buffer.allocUnsafe(1024);
+const binary = new mongo.Binary(buffer, 2);
+
+new Bench.Suite()
+  .add('clone Binary', function() {
+    clone(binary);
+  })
+  .add('clone Buffer', function() {
+    clone(buffer);
+  })
+  .add('clone Date', function() {
+    clone(date);
+  })
+  .add('clone ObjectId', function() {
+    clone(objId);
+  })
+  .add('clone document', function() {
+    clone(doc);
+  })
+  .add('clone RegExp', function() {
+    clone(/asdfasdf/gi);
+  })
+  .add('clone simple array', function() {
+    clone(simple);
+  })
+  .add('clone big array', function() {
+    clone(big);
+  })
+  .add('clone complex array', function() {
+    clone(complex);
+  })
+  .on('cycle', function(e) {
+    const s = String(e.target);
+    console.log(s);
+  })
+  .run();
+

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -76,7 +76,7 @@ function Query(criteria, options) {
 
 let $withinCmd = '$geoWithin';
 Object.defineProperty(Query, 'use$geoWithin', {
-  get: function() { return $withinCmd == '$geoWithin'; },
+  get: function() { return $withinCmd === '$geoWithin'; },
   set: function(v) {
     if (true === v) {
       // mongodb >= 2.4
@@ -176,7 +176,7 @@ Query.prototype.setOptions = function(options) {
     method = methods[i];
 
     // use methods if exist (safer option manipulation)
-    if ('function' == typeof this[method]) {
+    if ('function' === typeof this[method]) {
       const args = Array.isArray(options[method])
         ? options[method]
         : [options[method]];
@@ -278,7 +278,7 @@ Query.prototype.where = function() {
 
   const type = typeof arguments[0];
 
-  if ('string' == type) {
+  if ('string' === type) {
     this._path = arguments[0];
 
     if (2 === arguments.length) {
@@ -288,7 +288,7 @@ Query.prototype.where = function() {
     return this;
   }
 
-  if ('object' == type && !Array.isArray(arguments[0])) {
+  if ('object' === type && !Array.isArray(arguments[0])) {
     return this.merge(arguments[0]);
   }
 
@@ -675,7 +675,7 @@ Query.prototype.exists = function() {
  */
 
 Query.prototype.elemMatch = function() {
-  if (null == arguments[0])
+  if (null === arguments[0] || undefined === arguments[0])
     throw new TypeError('Invalid argument');
 
   let fn, path, criteria;
@@ -830,7 +830,7 @@ Query.prototype.box = function() {
 Query.prototype.polygon = function() {
   let val, path;
 
-  if ('string' == typeof arguments[0]) {
+  if ('string' === typeof arguments[0]) {
     // polygon('loc', [],[],[])
     val = Array.from(arguments);
     path = val.shift();
@@ -1058,10 +1058,10 @@ Query.prototype.intersects = function intersects() {
  */
 
 Query.prototype.geometry = function geometry() {
-  if (!('$within' == this._geoComparison ||
-        '$geoWithin' == this._geoComparison ||
-        '$near' == this._geoComparison ||
-        '$geoIntersects' == this._geoComparison)) {
+  if (!('$within' === this._geoComparison ||
+        '$geoWithin' === this._geoComparison ||
+        '$near' === this._geoComparison ||
+        '$geoIntersects' === this._geoComparison)) {
     throw new Error('geometry() must come after `within()`, `intersects()`, or `near()');
   }
 
@@ -1112,6 +1112,7 @@ Query.prototype.geometry = function geometry() {
  * @see SchemaType
  * @api public
  */
+const whitespaceRE = /\s+/;
 
 Query.prototype.select = function select() {
   let arg = arguments[0];
@@ -1127,15 +1128,15 @@ Query.prototype.select = function select() {
   const type = typeof arg;
   let i, len;
 
-  if (('string' == type || utils.isArgumentsObject(arg)) &&
-    'number' == typeof arg.length || Array.isArray(arg)) {
-    if ('string' == type)
-      arg = arg.split(/\s+/);
+  if (('string' === type || utils.isArgumentsObject(arg)) &&
+    'number' === typeof arg.length || Array.isArray(arg)) {
+    if ('string' === type)
+      arg = arg.split(whitespaceRE);
 
     for (i = 0, len = arg.length; i < len; ++i) {
       let field = arg[i];
       if (!field) continue;
-      const include = '-' == field[0] ? 0 : 1;
+      const include = '-' === field[0] ? 0 : 1;
       if (include === 0) field = field.substring(1);
       fields[field] = include;
     }
@@ -1247,7 +1248,7 @@ Query.prototype.sort = function(arg) {
   // .sort([['field', 1], ['test', -1]])
   if (Array.isArray(arg)) {
     len = arg.length;
-    for (i = 0; i < arg.length; ++i) {
+    for (i = 0; i < len; ++i) {
       if (!Array.isArray(arg[i])) {
         throw new Error('Invalid sort() argument, must be array of arrays');
       }
@@ -1257,13 +1258,13 @@ Query.prototype.sort = function(arg) {
   }
 
   // .sort('field -test')
-  if (1 === arguments.length && 'string' == type) {
-    arg = arg.split(/\s+/);
+  if (1 === arguments.length && 'string' === type) {
+    arg = arg.split(whitespaceRE);
     len = arg.length;
     for (i = 0; i < len; ++i) {
       field = arg[i];
       if (!field) continue;
-      const ascend = '-' == field[0] ? -1 : 1;
+      const ascend = '-' === field[0] ? -1 : 1;
       if (ascend === -1) field = field.substring(1);
       push(this.options, field, ascend);
     }
@@ -2104,7 +2105,7 @@ Query.prototype.distinct = function(criteria, field, callback) {
     switch (typeof field) {
       case 'function':
         callback = field;
-        if ('string' == typeof criteria) {
+        if ('string' === typeof criteria) {
           field = criteria;
           criteria = undefined;
         }
@@ -2128,7 +2129,7 @@ Query.prototype.distinct = function(criteria, field, callback) {
     }
   }
 
-  if ('string' == typeof field) {
+  if ('string' === typeof field) {
     this._distinct = field;
   }
 
@@ -2241,13 +2242,13 @@ Query.prototype.update = function update(criteria, doc, options, callback) {
 
   switch (arguments.length) {
     case 3:
-      if ('function' == typeof options) {
+      if ('function' === typeof options) {
         callback = options;
         options = undefined;
       }
       break;
     case 2:
-      if ('function' == typeof doc) {
+      if ('function' === typeof doc) {
         callback = doc;
         doc = criteria;
         criteria = undefined;
@@ -2299,13 +2300,13 @@ Query.prototype.updateMany = function updateMany(criteria, doc, options, callbac
 
   switch (arguments.length) {
     case 3:
-      if ('function' == typeof options) {
+      if ('function' === typeof options) {
         callback = options;
         options = undefined;
       }
       break;
     case 2:
-      if ('function' == typeof doc) {
+      if ('function' === typeof doc) {
         callback = doc;
         doc = criteria;
         criteria = undefined;
@@ -2357,13 +2358,13 @@ Query.prototype.updateOne = function updateOne(criteria, doc, options, callback)
 
   switch (arguments.length) {
     case 3:
-      if ('function' == typeof options) {
+      if ('function' === typeof options) {
         callback = options;
         options = undefined;
       }
       break;
     case 2:
-      if ('function' == typeof doc) {
+      if ('function' === typeof doc) {
         callback = doc;
         doc = criteria;
         criteria = undefined;
@@ -2414,13 +2415,13 @@ Query.prototype.replaceOne = function replaceOne(criteria, doc, options, callbac
 
   switch (arguments.length) {
     case 3:
-      if ('function' == typeof options) {
+      if ('function' === typeof options) {
         callback = options;
         options = undefined;
       }
       break;
     case 2:
-      if ('function' == typeof doc) {
+      if ('function' === typeof doc) {
         callback = doc;
         doc = criteria;
         criteria = undefined;
@@ -2700,13 +2701,13 @@ Query.prototype.findOneAndUpdate = function(criteria, doc, options, callback) {
 
   switch (arguments.length) {
     case 3:
-      if ('function' == typeof options) {
+      if ('function' === typeof options) {
         callback = options;
         options = {};
       }
       break;
     case 2:
-      if ('function' == typeof doc) {
+      if ('function' === typeof doc) {
         callback = doc;
         doc = criteria;
         criteria = undefined;
@@ -2714,7 +2715,7 @@ Query.prototype.findOneAndUpdate = function(criteria, doc, options, callback) {
       options = undefined;
       break;
     case 1:
-      if ('function' == typeof criteria) {
+      if ('function' === typeof criteria) {
         callback = criteria;
         criteria = options = doc = undefined;
       } else {
@@ -2774,10 +2775,10 @@ Query.prototype.findOneAndRemove = Query.prototype.findOneAndDelete = function(c
   this.op = 'findOneAndRemove';
   this._validate();
 
-  if ('function' == typeof options) {
+  if ('function' === typeof options) {
     callback = options;
     options = undefined;
-  } else if ('function' == typeof conditions) {
+  } else if ('function' === typeof conditions) {
     callback = conditions;
     conditions = undefined;
   }
@@ -2883,13 +2884,13 @@ Query.prototype.exec = function exec(op, callback) {
 
   assert.ok(this.op, 'Missing query type: (find, update, etc)');
 
-  if ('update' == this.op || 'remove' == this.op) {
+  if ('update' === this.op || 'remove' === this.op) {
     callback || (callback = true);
   }
 
   const _this = this;
 
-  if ('function' == typeof callback) {
+  if ('function' === typeof callback) {
     this[this.op](callback);
   } else {
     return new Query.Promise(function(success, error) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,10 @@
  * Module dependencies.
  */
 
-const specialProperties = ['__proto__', 'constructor', 'prototype'];
+const specialProperties = new Set(['__proto__', 'constructor', 'prototype']);
+const primitiveTypes = new Set(['bigint', 'string', 'number', 'boolean', 'symbol', 'undefined']);
+const objectIdVariants = new Set(['ObjectId', 'ObjectID']);
+const dateVariants = new Set(['Date', 'Function']);
 
 /**
  * Clones objects
@@ -16,44 +19,55 @@ const specialProperties = ['__proto__', 'constructor', 'prototype'];
  */
 
 const clone = exports.clone = function clone(obj, options) {
-  if (obj === undefined || obj === null)
+  if (obj === null || primitiveTypes.has(typeof obj)) {
     return obj;
+  }
 
-  if (Array.isArray(obj))
+  if (Array.isArray(obj)) {
     return exports.cloneArray(obj, options);
+  }
+
+  if (obj instanceof Date) {
+    return new Date(obj);
+  }
+
+  if (obj instanceof RegExp) {
+    return new RegExp(obj.source, obj.flags);
+  }
+
+  if (Buffer.isBuffer(obj)) {
+    return Buffer.from(obj.slice());
+  }
 
   if (obj.constructor) {
-    if (/ObjectI[dD]$/.test(obj.constructor.name)) {
-      return 'function' == typeof obj.clone
-        ? obj.clone()
-        : new obj.constructor(obj.id);
+    const constructorName = obj.constructor.name;
+    if (objectIdVariants.has(constructorName)) {
+      return typeof obj.clone === 'function' && obj.clone() ||
+        new obj.constructor(obj.id);
     }
 
-    if (obj.constructor.name === 'ReadPreference') {
+    if (dateVariants.has(constructorName)) {
+      return new obj.constructor(+obj);
+    }
+
+    if (obj._bsontype === 'Binary' && obj.buffer && obj.value) {
+      return typeof obj.clone === 'function' && obj.clone() ||
+        new obj.constructor(obj.value(true), obj.sub_type);
+    }
+
+    if (constructorName === 'ReadPreference') {
       return new obj.constructor(obj.mode, clone(obj.tags, options));
     }
 
-    if ('Binary' == obj._bsontype && obj.buffer && obj.value) {
-      return 'function' == typeof obj.clone
-        ? obj.clone()
-        : new obj.constructor(obj.value(true), obj.sub_type);
-    }
-
-    if ('Date' === obj.constructor.name || 'Function' === obj.constructor.name)
-      return new obj.constructor(+obj);
-
-    if ('RegExp' === obj.constructor.name)
-      return new RegExp(obj);
-
-    if ('Buffer' === obj.constructor.name)
-      return Buffer.from(obj);
   }
 
-  if (isObject(obj))
+  if (isObject(obj)) {
     return exports.cloneObject(obj, options);
+  }
 
-  if (obj.valueOf)
+  if (obj.valueOf) {
     return obj.valueOf();
+  }
 };
 
 /*!
@@ -74,13 +88,13 @@ exports.cloneObject = function cloneObject(obj, options) {
     k = keys[i];
     // Not technically prototype pollution because this wouldn't merge properties
     // onto `Object.prototype`, but avoid properties like __proto__ as a precaution.
-    if (specialProperties.indexOf(k) !== -1) {
+    if (specialProperties.has(k)) {
       continue;
     }
 
     val = clone(obj[k], options);
 
-    if (!minimize || ('undefined' !== typeof val)) {
+    if (!minimize || (typeof val !== 'undefined')) {
       hasKeys || (hasKeys = true);
       ret[k] = val;
     }
@@ -92,11 +106,12 @@ exports.cloneObject = function cloneObject(obj, options) {
 };
 
 exports.cloneArray = function cloneArray(arr, options) {
-  const ret = [],
-      l = arr.length;
+  const len = arr.length,
+      ret = new Array(len);
   let i = 0;
-  for (; i < l; i++)
-    ret.push(clone(arr[i], options));
+  for (; i < len; ++i) {
+    ret[i] = clone(arr[i], options);
+  }
   return ret;
 };
 
@@ -141,10 +156,10 @@ exports.merge = function merge(to, from) {
   const keys = Object.keys(from);
 
   for (const key of keys) {
-    if (specialProperties.indexOf(key) !== -1) {
+    if (specialProperties.has(key)) {
       continue;
     }
-    if ('undefined' === typeof to[key]) {
+    if (typeof to[key] === 'undefined') {
       to[key] = from[key];
     } else {
       if (exports.isObject(from[key])) {
@@ -168,10 +183,10 @@ exports.mergeClone = function mergeClone(to, from) {
   const keys = Object.keys(from);
 
   for (const key of keys) {
-    if (specialProperties.indexOf(key) !== -1) {
+    if (specialProperties.has(key)) {
       continue;
     }
-    if ('undefined' === typeof to[key]) {
+    if (typeof to[key] === 'undefined') {
       to[key] = clone(from[key]);
     } else {
       if (exports.isObject(from[key])) {
@@ -197,26 +212,16 @@ exports.mergeClone = function mergeClone(to, from) {
  * @param {String} pref
  */
 
-exports.readPref = function readPref(pref) {
-  switch (pref) {
-    case 'p':
-      pref = 'primary';
-      break;
-    case 'pp':
-      pref = 'primaryPreferred';
-      break;
-    case 's':
-      pref = 'secondary';
-      break;
-    case 'sp':
-      pref = 'secondaryPreferred';
-      break;
-    case 'n':
-      pref = 'nearest';
-      break;
-  }
+const readPrefLookup = {
+  p: 'primary',
+  pp: 'primaryPreferred',
+  s: 'secondary',
+  sp: 'secondaryPreferred',
+  n: 'nearest'
+};
 
-  return pref;
+exports.readPref = function readPref(pref) {
+  return readPrefLookup[pref] || pref;
 };
 
 
@@ -233,27 +238,17 @@ exports.readPref = function readPref(pref) {
  *
  * @param {String|Object} concern
  */
+const readConcernLookup = {
+  l: 'local',
+  a: 'available',
+  m: 'majority',
+  lz: 'linearizable',
+  s: 'snapshot'
+};
 
 exports.readConcern = function readConcern(concern) {
-  if ('string' === typeof concern) {
-    switch (concern) {
-      case 'l':
-        concern = 'local';
-        break;
-      case 'a':
-        concern = 'available';
-        break;
-      case 'm':
-        concern = 'majority';
-        break;
-      case 'lz':
-        concern = 'linearizable';
-        break;
-      case 's':
-        concern = 'snapshot';
-        break;
-    }
-    concern = { level: concern };
+  if (typeof concern === 'string') {
+    concern = { level: readConcernLookup[concern] || concern };
   }
   return concern;
 };
@@ -263,7 +258,7 @@ exports.readConcern = function readConcern(concern) {
  */
 
 const _toString = Object.prototype.toString;
-exports.toString = function(arg) {
+exports.toString = function toString(arg) {
   return _toString.call(arg);
 };
 
@@ -274,8 +269,8 @@ exports.toString = function(arg) {
  * @return {Boolean}
  */
 
-const isObject = exports.isObject = function(arg) {
-  return '[object Object]' == exports.toString(arg);
+const isObject = exports.isObject = function isObject(arg) {
+  return _toString.call(arg) === '[object Object]';
 };
 
 /**
@@ -291,7 +286,7 @@ exports.keys = Object.keys;
  * Based on https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object/create
  */
 
-exports.create = 'function' == typeof Object.create
+exports.create = typeof Object.create === 'function'
   ? Object.create
   : create;
 
@@ -309,7 +304,7 @@ function create(proto) {
  * inheritance
  */
 
-exports.inherits = function(ctor, superCtor) {
+exports.inherits = function inherits(ctor, superCtor) {
   ctor.prototype = exports.create(superCtor.prototype);
   ctor.prototype.constructor = ctor;
 };
@@ -319,7 +314,7 @@ exports.inherits = function(ctor, superCtor) {
  * compat with node 0.10 which behaves differently than previous versions
  */
 
-const soon = exports.soon = 'function' == typeof setImmediate
+const soon = exports.soon = typeof setImmediate === 'function'
   ? setImmediate
   : process.nextTick;
 
@@ -330,6 +325,6 @@ const soon = exports.soon = 'function' == typeof setImmediate
  * @return {Boolean}
  */
 
-exports.isArgumentsObject = function(v) {
-  return Object.prototype.toString.call(v) === '[object Arguments]';
+exports.isArgumentsObject = function isArgumentsObject(v) {
+  return _toString.call(v) === '[object Arguments]';
 };

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "debug": "4.x"
   },
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "eslint": "8.x",
     "eslint-plugin-mocha-no-only": "1.1.1",
     "mocha": "9.x",

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -130,6 +130,7 @@ describe('lib/utils', function() {
       assert.equal(binary.sub_type, clone.sub_type);
       assert.equal(String(binary.buffer), String(buf));
       assert.ok(binary !== clone);
+      assert.ok(binary.buffer !== clone.buffer);
       done();
     });
 
@@ -158,6 +159,7 @@ describe('lib/utils', function() {
         assert.equal(buff[i], clone[i]);
       }
 
+      assert.ok(buff.buffer !== clone.buffer);
       done();
     });
 


### PR DESCRIPTION
I also added benchmarks:
before:
```
node clone
clone Binary x 6,092,545 ops/sec ±0.35% (95 runs sampled)
clone Buffer x 1,685,261 ops/sec ±0.80% (89 runs sampled)
clone Date x 3,855,007 ops/sec ±0.21% (95 runs sampled)
clone ObjectId x 13,318,948 ops/sec ±0.59% (95 runs sampled)
clone document x 20,405 ops/sec ±1.05% (92 runs sampled)
clone RegExp x 3,101,792 ops/sec ±0.93% (90 runs sampled)
clone simple array x 46,953 ops/sec ±1.51% (85 runs sampled)
clone big array x 50.22 ops/sec ±1.06% (65 runs sampled)
clone complex array x 174 ops/sec ±2.24% (78 runs sampled)
```

after:
```
node clone
clone Binary x 6,197,530 ops/sec ±0.27% (95 runs sampled)
clone Buffer x 1,846,515 ops/sec ±1.56% (80 runs sampled)
clone Date x 9,323,686 ops/sec ±0.33% (90 runs sampled)
clone ObjectId x 12,511,455 ops/sec ±0.71% (94 runs sampled)
clone document x 92,521 ops/sec ±0.32% (92 runs sampled)
clone RegExp x 8,146,014 ops/sec ±0.34% (93 runs sampled)
clone simple array x 518,904 ops/sec ±0.21% (95 runs sampled)
clone big array x 481 ops/sec ±0.50% (88 runs sampled)
clone complex array x 883 ops/sec ±0.14% (95 runs sampled)
```

It is imho better balanced performance wise. Arrays and documents are significantly faster, which should be the usual business case.