### PR TITLE
Remove Functions / Options for Mongoose 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ require('mongodb').connect(uri, function (err, db) {
     - [hint()](#hint)
     - [j()](#j)
     - [limit()](#limit)
-    - [maxScan()](#maxscan)
     - [maxTime()](#maxtime)
     - [skip()](#skip)
     - [sort()](#sort)
@@ -829,18 +828,6 @@ _Cannot be used with `distinct()`._
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/method/cursor.limit/)
 
-### maxScan()
-
-Specifies the maxScan option.
-
-```js
-query.maxScan(100)
-```
-
-_Cannot be used with `distinct()`._
-
-[MongoDB documentation](http://docs.mongodb.org/manual/reference/operator/maxScan/)
-
 ### maxTime()
 
 Specifies the maxTimeMS option.
@@ -1161,7 +1148,6 @@ mquery().setOptions({ collection: coll, limit: 20 })
 - [sort](#sort) *
 - [limit](#limit) *
 - [skip](#skip) *
-- [maxScan](#maxscan) *
 - [maxTime](#maxtime) *
 - [batchSize](#batchSize) *
 - [comment](#comment) *

--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ require('mongodb').connect(uri, function (err, db) {
     - [find()](#find)
     - [findOne()](#findone)
     - [count()](#count)
-    - [update()](#update)
-        - [the update document](#the-update-document)
-        - [options](#options)
     - [findOneAndUpdate()](#findoneandupdate)
         - [options](#options-1)
     - [findOneAndRemove()](#findoneandremove)
@@ -190,93 +187,6 @@ mquery().count(callback)
 mquery().count(match, function (err, number){
   console.log('we found %d matching documents', number);
 })
-```
-
-### update()
-
-Declares this query an _update_ query. Optionally pass an update document, match clause, options or callback. If a callback is passed, the query is executed. To force execution without passing a callback, run `update(true)`.
-
-```js
-mquery().update()
-mquery().update(match, updateDocument)
-mquery().update(match, updateDocument, options)
-
-// the following all execute the command
-mquery().update(callback)
-mquery().update({$set: updateDocument, callback)
-mquery().update(match, updateDocument, callback)
-mquery().update(match, updateDocument, options, function (err, result){})
-mquery().update(true) // executes (unsafe write)
-```
-
-##### the update document
-
-All paths passed that are not `$atomic` operations will become `$set` ops. For example:
-
-```js
-mquery(collection).where({ _id: id }).update({ title: 'words' }, callback)
-```
-
-becomes
-
-```js
-collection.update({ _id: id }, { $set: { title: 'words' }}, callback)
-```
-
-This behavior can be overridden using the `overwrite` option (see below).
-
-##### options
-
-Options are passed to the `setOptions()` method.
-
-- overwrite
-
-Passing an empty object `{ }` as the update document will result in a no-op unless the `overwrite` option is passed. Without the `overwrite` option, the update operation will be ignored and the callback executed without sending the command to MongoDB to prevent accidently overwritting documents in the collection.
-
-```js
-var q = mquery(collection).where({ _id: id }).setOptions({ overwrite: true });
-q.update({ }, callback); // overwrite with an empty doc
-```
-
-The `overwrite` option isn't just for empty objects, it also provides a means to override the default `$set` conversion and send the update document as is.
-
-```js
-// create a base query
-var base = mquery({ _id: 108 }).collection(collection).toConstructor();
-
-base().findOne(function (err, doc) {
-  console.log(doc); // { _id: 108, name: 'cajon' })
-
-  base().setOptions({ overwrite: true }).update({ changed: true }, function (err) {
-    base.findOne(function (err, doc) {
-      console.log(doc); // { _id: 108, changed: true }) - the doc was overwritten
-    });
-  });
-})
-```
-
-- multi
-
-Updates only modify a single document by default. To update multiple documents, set the `multi` option to `true`.
-
-```js
-mquery()
-  .collection(coll)
-  .update({ name: /^match/ }, { $addToSet: { arr: 4 }}, { multi: true }, callback)
-
-// another way of doing it
-mquery({ name: /^match/ })
-  .collection(coll)
-  .setOptions({ multi: true })
-  .update({ $addToSet: { arr: 4 }}, callback)
-
-// update multiple documents with an empty doc
-var q = mquery(collection).where({ name: /^match/ });
-q.setOptions({ multi: true, overwrite: true })
-q.update({ });
-q.update(function (err, result) {
-  console.log(arguments);
-});
 ```
 
 ### findOneAndUpdate()
@@ -898,7 +808,6 @@ This option is only valid for operations that write to the database:
 - `deleteMany()`
 - `findOneAndDelete()`
 - `findOneAndUpdate()`
-- `update()`
 - `updateOne()`
 - `updateMany()`
 
@@ -1090,7 +999,6 @@ This option is only valid for operations that write to the database:
 - `deleteMany()`
 - `findOneAndDelete()`
 - `findOneAndUpdate()`
-- `update()`
 - `updateOne()`
 - `updateMany()`
 
@@ -1171,7 +1079,6 @@ This option is only valid for operations that write to the database:
 - `deleteMany()`
 - `findOneAndDelete()`
 - `findOneAndUpdate()`
-- `update()`
 - `updateOne()`
 - `updateMany()`
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ require('mongodb').connect(uri, function (err, db) {
     - [writeConcern()](#writeconcern)
         - [Write Concern:](#write-concern)
     - [slaveOk()](#slaveok)
-    - [snapshot()](#snapshot)
     - [tailable()](#tailable)
     - [wtimeout()](#wtimeout)
   - [Helpers](#helpers-1)
@@ -1027,20 +1026,6 @@ query.slaveOk(false)
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/method/rs.slaveOk/)
 
-### snapshot()
-
-Specifies this query as a snapshot query.
-
-```js
-mquery().snapshot() // true
-mquery().snapshot(true)
-mquery().snapshot(false)
-```
-
-_Cannot be used with `distinct()`._
-
-[MongoDB documentation](http://docs.mongodb.org/manual/reference/operator/snapshot/)
-
 ### tailable()
 
 Sets tailable option.
@@ -1151,7 +1136,6 @@ mquery().setOptions({ collection: coll, limit: 20 })
 - [maxTime](#maxtime) *
 - [batchSize](#batchSize) *
 - [comment](#comment) *
-- [snapshot](#snapshot) *
 - [hint](#hint) *
 - [collection](#collection): the collection to query against
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ require('mongodb').connect(uri, function (err, db) {
     - [find()](#find)
     - [findOne()](#findone)
     - [count()](#count)
-    - [remove()](#remove)
     - [update()](#update)
         - [the update document](#the-update-document)
         - [options](#options)
@@ -191,17 +190,6 @@ mquery().count(callback)
 mquery().count(match, function (err, number){
   console.log('we found %d matching documents', number);
 })
-```
-
-### remove()
-
-Declares this query a _remove_ query. Optionally pass a match clause and / or callback. If a callback is passed the query is executed.
-
-```js
-mquery().remove()
-mquery().remove(match)
-mquery().remove(callback)
-mquery().remove(match, function (err){})
 ```
 
 ### update()
@@ -910,7 +898,6 @@ This option is only valid for operations that write to the database:
 - `deleteMany()`
 - `findOneAndDelete()`
 - `findOneAndUpdate()`
-- `remove()`
 - `update()`
 - `updateOne()`
 - `updateMany()`
@@ -1103,7 +1090,6 @@ This option is only valid for operations that write to the database:
 - `deleteMany()`
 - `findOneAndDelete()`
 - `findOneAndUpdate()`
-- `remove()`
 - `update()`
 - `updateOne()`
 - `updateMany()`
@@ -1185,7 +1171,6 @@ This option is only valid for operations that write to the database:
 - `deleteMany()`
 - `findOneAndDelete()`
 - `findOneAndUpdate()`
-- `remove()`
 - `update()`
 - `updateOne()`
 - `updateMany()`

--- a/lib/collection/collection.js
+++ b/lib/collection/collection.js
@@ -11,7 +11,6 @@ const methods = [
   'updateMany',
   'updateOne',
   'replaceOne',
-  'remove',
   'count',
   'distinct',
   'findOneAndDelete',

--- a/lib/collection/collection.js
+++ b/lib/collection/collection.js
@@ -7,7 +7,6 @@
 const methods = [
   'find',
   'findOne',
-  'update',
   'updateMany',
   'updateOne',
   'replaceOne',

--- a/lib/collection/node.js
+++ b/lib/collection/node.js
@@ -51,13 +51,6 @@ class NodeCollection extends Collection {
   /**
    * update(match, update, options, function(err[, result]))
    */
-  update(match, update, options, cb) {
-    this.collection.update(match, update, options, cb);
-  }
-
-  /**
-   * update(match, update, options, function(err[, result]))
-   */
   updateMany(match, update, options, cb) {
     this.collection.updateMany(match, update, options, cb);
   }

--- a/lib/collection/node.js
+++ b/lib/collection/node.js
@@ -91,13 +91,6 @@ class NodeCollection extends Collection {
   }
 
   /**
-   * remove(match, options, function(err[, result])
-   */
-  remove(match, options, cb) {
-    this.collection.remove(match, options, cb);
-  }
-
-  /**
    * findOneAndDelete(match, options, function(err[, result])
    */
   findOneAndDelete(match, options, cb) {

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -1557,7 +1557,6 @@ Query.prototype.hint = function() {
  * - `deleteMany()`
  * - `findOneAndDelete()`
  * - `findOneAndUpdate()`
- * - `remove()`
  * - `update()`
  * - `updateOne()`
  * - `updateMany()`
@@ -1752,7 +1751,6 @@ Query.prototype.tailable = function() {
  * - `deleteMany()`
  * - `findOneAndDelete()`
  * - `findOneAndUpdate()`
- * - `remove()`
  * - `update()`
  * - `updateOne()`
  * - `updateMany()`
@@ -1801,7 +1799,6 @@ Query.prototype.writeConcern = Query.prototype.w = function writeConcern(concern
  * - `deleteMany()`
  * - `findOneAndDelete()`
  * - `findOneAndUpdate()`
- * - `remove()`
  * - `update()`
  * - `updateOne()`
  * - `updateMany()`
@@ -2496,75 +2493,7 @@ function _update(query, op, criteria, doc, options, force, callback) {
 }
 
 /**
- * Declare and/or execute this query as a remove() operation.
- *
- * #### Example:
- *
- *     mquery(collection).remove({ artist: 'Anne Murray' }, callback)
- *
- * #### Note:
- *
- * The operation is only executed when a callback is passed. To force execution without a callback (which would be an unsafe write), we must first call remove() and then execute it by using the `exec()` method.
- *
- *     // not executed
- *     var query = mquery(collection).remove({ name: 'Anne Murray' })
- *
- *     // executed
- *     mquery(collection).remove({ name: 'Anne Murray' }, callback)
- *     mquery(collection).remove({ name: 'Anne Murray' }).remove(callback)
- *
- *     // executed without a callback (unsafe write)
- *     query.exec()
- *
- *     // summary
- *     query.remove(conds, fn); // executes
- *     query.remove(conds)
- *     query.remove(fn) // executes
- *     query.remove()
- *
- * @param {Object|Query} [criteria] mongodb selector
- * @param {Function} [callback]
- * @return {Query} this
- * @api public
- */
-
-Query.prototype.remove = function(criteria, callback) {
-  this.op = 'remove';
-  let force;
-
-  if ('function' === typeof criteria) {
-    callback = criteria;
-    criteria = undefined;
-  } else if (Query.canMerge(criteria)) {
-    this.merge(criteria);
-  } else if (true === criteria) {
-    force = criteria;
-    criteria = undefined;
-  }
-
-  if (!(force || callback))
-    return this;
-
-  const options = this._optionsForExec();
-  if (!callback) options.safe = false;
-
-  const conds = this._conditions;
-
-  debug('remove', this._collection.collectionName, conds, options);
-  callback = this._wrapCallback('remove', callback, {
-    conditions: conds,
-    options: options
-  });
-
-  this._collection.remove(conds, options, utils.tick(callback));
-
-  return this;
-};
-
-/**
- * Declare and/or execute this query as a `deleteOne()` operation. Behaves like
- * `remove()`, except for ignores the `justOne` option and always deletes at
- * most one document.
+ * Declare and/or execute this query as a `deleteOne()` operation.
  *
  * #### Example:
  *
@@ -2611,8 +2540,7 @@ Query.prototype.deleteOne = function(criteria, callback) {
 };
 
 /**
- * Declare and/or execute this query as a `deleteMany()` operation. Behaves like
- * `remove()`, except for ignores the `justOne` option and always deletes
+ * Declare and/or execute this query as a `deleteMany()` operation. Always deletes
  * _every_ document that matches `criteria`.
  *
  * #### Example:
@@ -2879,7 +2807,7 @@ Query.prototype.exec = function exec(op, callback) {
 
   assert.ok(this.op, 'Missing query type: (find, update, etc)');
 
-  if ('update' == this.op || 'remove' == this.op) {
+  if ('update' == this.op) {
     callback || (callback = true);
   }
 

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -1557,7 +1557,6 @@ Query.prototype.hint = function() {
  * - `deleteMany()`
  * - `findOneAndDelete()`
  * - `findOneAndUpdate()`
- * - `update()`
  * - `updateOne()`
  * - `updateMany()`
  *
@@ -1751,7 +1750,6 @@ Query.prototype.tailable = function() {
  * - `deleteMany()`
  * - `findOneAndDelete()`
  * - `findOneAndUpdate()`
- * - `update()`
  * - `updateOne()`
  * - `updateMany()`
  *
@@ -1799,7 +1797,6 @@ Query.prototype.writeConcern = Query.prototype.w = function writeConcern(concern
  * - `deleteMany()`
  * - `findOneAndDelete()`
  * - `findOneAndUpdate()`
- * - `update()`
  * - `updateOne()`
  * - `updateMany()`
  *
@@ -2152,124 +2149,7 @@ Query.prototype.distinct = function(criteria, field, callback) {
 };
 
 /**
- * Declare and/or execute this query as an update() operation. By default,
- * `update()` only modifies the _first_ document that matches `criteria`.
- *
- * _All paths passed that are not $atomic operations will become $set ops._
- *
- * #### Example:
- *
- *     mquery({ _id: id }).update({ title: 'words' }, ...)
- *
- * becomes
- *
- *     collection.update({ _id: id }, { $set: { title: 'words' }}, ...)
- *
- * #### Note:
- *
- * Passing an empty object `{}` as the doc will result in a no-op unless the `overwrite` option is passed. Without the `overwrite` option set, the update operation will be ignored and the callback executed without sending the command to MongoDB so as to prevent accidently overwritting documents in the collection.
- *
- * #### Note:
- *
- * The operation is only executed when a callback is passed. To force execution without a callback (which would be an unsafe write), we must first call update() and then execute it by using the `exec()` method.
- *
- *     var q = mquery(collection).where({ _id: id });
- *     q.update({ $set: { name: 'bob' }}).update(); // not executed
- *
- *     var q = mquery(collection).where({ _id: id });
- *     q.update({ $set: { name: 'bob' }}).exec(); // executed as unsafe
- *
- *     // keys that are not $atomic ops become $set.
- *     // this executes the same command as the previous example.
- *     q.update({ name: 'bob' }).where({ _id: id }).exec();
- *
- *     var q = mquery(collection).update(); // not executed
- *
- *     // overwriting with empty docs
- *     var q.where({ _id: id }).setOptions({ overwrite: true })
- *     q.update({ }, callback); // executes
- *
- *     // multi update with overwrite to empty doc
- *     var q = mquery(collection).where({ _id: id });
- *     q.setOptions({ multi: true, overwrite: true })
- *     q.update({ });
- *     q.update(callback); // executed
- *
- *     // multi updates
- *     mquery()
- *       .collection(coll)
- *       .update({ name: /^match/ }, { $set: { arr: [] }}, { multi: true }, callback)
- *     // more multi updates
- *     mquery({ })
- *       .collection(coll)
- *       .setOptions({ multi: true })
- *       .update({ $set: { arr: [] }}, callback)
- *
- *     // single update by default
- *     mquery({ email: 'address@example.com' })
- *      .collection(coll)
- *      .update({ $inc: { counter: 1 }}, callback)
- *
- *     // summary
- *     update(criteria, doc, opts, cb) // executes
- *     update(criteria, doc, opts)
- *     update(criteria, doc, cb) // executes
- *     update(criteria, doc)
- *     update(doc, cb) // executes
- *     update(doc)
- *     update(cb) // executes
- *     update(true) // executes (unsafe write)
- *     update()
- *
- * @param {Object} [criteria]
- * @param {Object} [doc] the update command
- * @param {Object} [options]
- * @param {Function} [callback]
- * @return {Query} this
- * @api public
- */
-
-Query.prototype.update = function update(criteria, doc, options, callback) {
-  let force;
-
-  switch (arguments.length) {
-    case 3:
-      if ('function' == typeof options) {
-        callback = options;
-        options = undefined;
-      }
-      break;
-    case 2:
-      if ('function' == typeof doc) {
-        callback = doc;
-        doc = criteria;
-        criteria = undefined;
-      }
-      break;
-    case 1:
-      switch (typeof criteria) {
-        case 'function':
-          callback = criteria;
-          criteria = options = doc = undefined;
-          break;
-        case 'boolean':
-          // execution with no callback (unsafe write)
-          force = criteria;
-          criteria = undefined;
-          break;
-        default:
-          doc = criteria;
-          criteria = options = undefined;
-          break;
-      }
-  }
-
-  return _update(this, 'update', criteria, doc, options, force, callback);
-};
-
-/**
- * Declare and/or execute this query as an `updateMany()` operation. Identical
- * to `update()` except `updateMany()` will update _all_ documents that match
+ * Declare and/or execute this query as an `updateMany()` operation. This function will update _all_ documents that match
  * `criteria`, rather than just the first one.
  *
  * _All paths passed that are not $atomic operations will become $set ops._
@@ -2326,8 +2206,7 @@ Query.prototype.updateMany = function updateMany(criteria, doc, options, callbac
 };
 
 /**
- * Declare and/or execute this query as an `updateOne()` operation. Identical
- * to `update()` except `updateOne()` will _always_ update just one document,
+ * Declare and/or execute this query as an `updateOne()` operation. This function will _always_ update just one document,
  * regardless of the `multi` option.
  *
  * _All paths passed that are not $atomic operations will become $set ops._
@@ -2443,7 +2322,7 @@ Query.prototype.replaceOne = function replaceOne(criteria, doc, options, callbac
 
 
 /*!
- * Internal helper for update, updateMany, updateOne
+ * Internal helper for updateMany, updateOne
  */
 
 function _update(query, op, criteria, doc, options, force, callback) {
@@ -2480,7 +2359,7 @@ function _update(query, op, criteria, doc, options, force, callback) {
   criteria = query._conditions;
   doc = query._updateForExec();
 
-  debug('update', query._collection.collectionName, criteria, doc, options);
+  debug('_update', query._collection.collectionName, criteria, doc, options);
   callback = query._wrapCallback(op, callback, {
     conditions: criteria,
     doc: doc,
@@ -2786,7 +2665,6 @@ Query.prototype.setTraceFunction = function(traceFunction) {
  *
  *     query.exec();
  *     query.exec(callback);
- *     query.exec('update');
  *     query.exec('find', callback);
  *
  * @param {String|Function} [operation]
@@ -2805,11 +2683,7 @@ Query.prototype.exec = function exec(op, callback) {
       break;
   }
 
-  assert.ok(this.op, 'Missing query type: (find, update, etc)');
-
-  if ('update' == this.op) {
-    callback || (callback = true);
-  }
+  assert.ok(this.op, 'Missing query type: (find, etc)');
 
   const _this = this;
 

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -148,7 +148,6 @@ Query.prototype.toConstructor = function toConstructor() {
  * - [sort](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%7B%7Bsort(\)%7D%7D) *
  * - [limit](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%7B%7Blimit%28%29%7D%7D) *
  * - [skip](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%7B%7Bskip%28%29%7D%7D) *
- * - [maxScan](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24maxScan) *
  * - [maxTime](http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS/#op._S_maxTimeMS) *
  * - [batchSize](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%7B%7BbatchSize%28%29%7D%7D) *
  * - [comment](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24comment) *
@@ -1390,23 +1389,6 @@ function _pushMap(opts, map) {
  * @api public
  */
 /**
- * Specifies the maxScan option.
- *
- * #### Example:
- *
- *     query.maxScan(100)
- *
- * #### Note:
- *
- * Cannot be used with `distinct()`
- *
- * @method maxScan
- * @memberOf Query
- * @param {Number} val
- * @see mongodb http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24maxScan
- * @api public
- */
-/**
  * Specifies the batchSize option.
  *
  * #### Example:
@@ -1442,14 +1424,14 @@ function _pushMap(opts, map) {
  */
 
 /*!
- * limit, skip, maxScan, batchSize, comment
+ * limit, skip, batchSize, comment
  *
  * Sets these associated options.
  *
  *     query.comment('feed query');
  */
 
-['limit', 'skip', 'maxScan', 'batchSize', 'comment'].forEach(function(method) {
+['limit', 'skip', 'batchSize', 'comment'].forEach(function(method) {
   Query.prototype[method] = function(v) {
     this._validate(method);
     this.options[method] = v;

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -151,7 +151,6 @@ Query.prototype.toConstructor = function toConstructor() {
  * - [maxTime](http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS/#op._S_maxTimeMS) *
  * - [batchSize](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%7B%7BbatchSize%28%29%7D%7D) *
  * - [comment](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24comment) *
- * - [snapshot](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%7B%7Bsnapshot%28%29%7D%7D) *
  * - [hint](http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24hint) *
  * - [slaveOk](http://docs.mongodb.org/manual/applications/replication/#read-preference) *
  * - [safe](http://www.mongodb.org/display/DOCS/getLastError+Command)
@@ -1457,34 +1456,6 @@ function _pushMap(opts, map) {
 Query.prototype.maxTime = Query.prototype.maxTimeMS = function(ms) {
   this._validate('maxTime');
   this.options.maxTimeMS = ms;
-  return this;
-};
-
-/**
- * Specifies this query as a `snapshot` query.
- *
- * #### Example:
- *
- *     mquery().snapshot() // true
- *     mquery().snapshot(true)
- *     mquery().snapshot(false)
- *
- * #### Note:
- *
- * Cannot be used with `distinct()`
- *
- * @see mongodb http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%7B%7Bsnapshot%28%29%7D%7D
- * @return {Query} this
- * @api public
- */
-
-Query.prototype.snapshot = function() {
-  this._validate('snapshot');
-
-  this.options.snapshot = arguments.length
-    ? !!arguments[0]
-    : true;
-
   return this;
 };
 

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -26,7 +26,6 @@ denied.distinct.sort =
 denied.distinct.limit =
 denied.distinct.skip =
 denied.distinct.batchSize =
-denied.distinct.snapshot =
 denied.distinct.hint =
 denied.distinct.tailable = true;
 
@@ -52,7 +51,6 @@ denied.findOneAndRemove = function(self) {
 denied.findOneAndUpdate.limit =
 denied.findOneAndUpdate.skip =
 denied.findOneAndUpdate.batchSize =
-denied.findOneAndUpdate.snapshot =
 denied.findOneAndUpdate.tailable = true;
 
 
@@ -77,5 +75,4 @@ denied.count = function(self) {
 
 denied.count.slice =
 denied.count.batchSize =
-denied.count.snapshot =
 denied.count.tailable = true;

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -26,7 +26,6 @@ denied.distinct.sort =
 denied.distinct.limit =
 denied.distinct.skip =
 denied.distinct.batchSize =
-denied.distinct.maxScan =
 denied.distinct.snapshot =
 denied.distinct.hint =
 denied.distinct.tailable = true;
@@ -53,7 +52,6 @@ denied.findOneAndRemove = function(self) {
 denied.findOneAndUpdate.limit =
 denied.findOneAndUpdate.skip =
 denied.findOneAndUpdate.batchSize =
-denied.findOneAndUpdate.maxScan =
 denied.findOneAndUpdate.snapshot =
 denied.findOneAndUpdate.tailable = true;
 
@@ -79,6 +77,5 @@ denied.count = function(self) {
 
 denied.count.slice =
 denied.count.batchSize =
-denied.count.maxScan =
 denied.count.snapshot =
 denied.count.tailable = true;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -108,7 +108,7 @@ exports.cloneArray = function cloneArray(arr, options) {
  *
  * node-mongodb-native had a habit of state corruption when
  * an error was immediately thrown from within a collection
- * method (find, update, etc) callback.
+ * method (find, etc) callback.
  *
  * @param {Function} [callback]
  * @api private

--- a/test/index.js
+++ b/test/index.js
@@ -1506,7 +1506,7 @@ describe('mquery', function() {
       });
 
       after(function(done) {
-        col.remove({ name: 'mquery' }, done);
+        col.deleteMany({ name: 'mquery' }, done);
       });
 
       it('when criteria is passed with a callback', function(done) {
@@ -1571,7 +1571,7 @@ describe('mquery', function() {
       });
 
       after(function(done) {
-        col.remove({ name: 'mquery findone' }, done);
+        col.deleteMany({ name: 'mquery findone' }, done);
       });
 
       it('when criteria is passed with a callback', function(done) {
@@ -1639,7 +1639,7 @@ describe('mquery', function() {
       });
 
       after(function(done) {
-        col.remove({ name: 'mquery count' }, done);
+        col.deleteMany({ name: 'mquery count' }, done);
       });
 
       it('when criteria is passed with a callback', function(done) {
@@ -1786,7 +1786,7 @@ describe('mquery', function() {
       });
 
       after(function(done) {
-        col.remove({ name: 'mquery distinct' }, done);
+        col.deleteMany({ name: 'mquery distinct' }, done);
       });
 
       it('when distinct arg is passed with a callback', function(done) {
@@ -1972,7 +1972,7 @@ describe('mquery', function() {
       });
 
       after(function(done) {
-        col.remove({ _id: id }, done);
+        col.deleteMany({ _id: id }, done);
       });
 
       describe('when conds + doc + opts + callback passed', function() {
@@ -2084,140 +2084,6 @@ describe('mquery', function() {
               done();
             });
           }, 300);
-        });
-      });
-    });
-  });
-
-  describe('remove', function() {
-    describe('with 0 args', function() {
-      const name = 'remove: no args test';
-      before(function(done) {
-        col.insertOne({ name: name }, done);
-      });
-      after(function(done) {
-        col.remove({ name: name }, done);
-      });
-
-      it('does not execute', function(done) {
-        const remove = col.remove;
-        col.remove = function() {
-          col.remove = remove;
-          done(new Error('remove executed!'));
-        };
-
-        mquery(col).where({ name: name }).remove();
-        setTimeout(function() {
-          col.remove = remove;
-          done();
-        }, 10);
-      });
-
-      it('chains', function() {
-        const m = mquery();
-        assert.equal(m, m.remove());
-      });
-    });
-
-    describe('with 1 argument', function() {
-      const name = 'remove: 1 arg test';
-      before(function(done) {
-        col.insertOne({ name: name }, done);
-      });
-      after(function(done) {
-        col.remove({ name: name }, done);
-      });
-
-      describe('that is a', function() {
-        it('plain object', function() {
-          const m = mquery(col).remove({ name: 'Whiskers' });
-          m.remove({ color: '#fff' });
-          assert.deepEqual({ name: 'Whiskers', color: '#fff' }, m._conditions);
-        });
-
-        it('query', function() {
-          const q = mquery({ color: '#fff' });
-          const m = mquery(col).remove({ name: 'Whiskers' });
-          m.remove(q);
-          assert.deepEqual({ name: 'Whiskers', color: '#fff' }, m._conditions);
-        });
-
-        it('function', function(done) {
-          mquery(col).where({ name: name }).remove(function(err) {
-            assert.ifError(err);
-            mquery(col).findOne({ name: name }, function(err, doc) {
-              assert.ifError(err);
-              assert.equal(null, doc);
-              done();
-            });
-          });
-        });
-
-        it('boolean (true) - execute', function(done) {
-          col.insertOne({ name: name }, function(err) {
-            assert.ifError(err);
-            mquery(col).findOne({ name: name }, function(err, doc) {
-              assert.ifError(err);
-              assert.ok(doc);
-              mquery(col).remove(true);
-              setTimeout(function() {
-                mquery(col).find(function(err, docs) {
-                  assert.ifError(err);
-                  assert.ok(docs);
-                  assert.equal(0, docs.length);
-                  done();
-                });
-              }, 300);
-            });
-          });
-        });
-      });
-    });
-
-    describe('with 2 arguments', function() {
-      const name = 'remove: 2 arg test';
-      beforeEach(function(done) {
-        col.remove({}, function(err) {
-          assert.ifError(err);
-          col.insertMany([{ name: 'shelly' }, { name: name }], function(err) {
-            assert.ifError(err);
-            mquery(col).find(function(err, docs) {
-              assert.ifError(err);
-              assert.equal(2, docs.length);
-              done();
-            });
-          });
-        });
-      });
-
-      describe('plain object + callback', function() {
-        it('works', function(done) {
-          mquery(col).remove({ name: name }, function(err) {
-            assert.ifError(err);
-            mquery(col).find(function(err, docs) {
-              assert.ifError(err);
-              assert.ok(docs);
-              assert.equal(1, docs.length);
-              assert.equal('shelly', docs[0].name);
-              done();
-            });
-          });
-        });
-      });
-
-      describe('mquery + callback', function() {
-        it('works', function(done) {
-          const m = mquery({ name: name });
-          mquery(col).remove(m, function(err) {
-            assert.ifError(err);
-            mquery(col).find(function(err, docs) {
-              assert.ifError(err);
-              assert.ok(docs);
-              assert.equal(1, docs.length);
-              assert.equal('shelly', docs[0].name);
-              done();
-            });
-          });
         });
       });
     });
@@ -2482,7 +2348,7 @@ describe('mquery', function() {
     });
 
     afterEach(function(done) {
-      mquery(col).remove(done);
+      mquery(col).deleteMany(done);
     });
 
     it('requires an op', function() {
@@ -2641,29 +2507,6 @@ describe('mquery', function() {
       });
     });
 
-    describe('remove', function() {
-      it('with a callback', function(done) {
-        const m = mquery(col).where({ age: 2 }).remove();
-        m.exec(function(err, res) {
-          assert.ifError(err);
-          assert.equal(1, res.deletedCount);
-          done();
-        });
-      });
-
-      it('without a callback', function(done) {
-        const m = mquery(col).where({ age: 1 }).remove();
-        m.exec();
-
-        setTimeout(function() {
-          mquery(col).where('name', 'exec').count(function(err, num) {
-            assert.equal(1, num);
-            done();
-          });
-        }, 200);
-      });
-    });
-
     describe('deleteOne', function() {
       it('with a callback', function(done) {
         const m = mquery(col).where({ age: { $gte: 0 } }).deleteOne();
@@ -2803,7 +2646,7 @@ describe('mquery', function() {
     });
 
     after(function(done) {
-      mquery(col).remove({ name: 'then' }).exec(done);
+      mquery(col).deleteMany({ name: 'then' }).exec(done);
     });
 
     it('returns a promise A+ compat object', function(done) {
@@ -2840,12 +2683,12 @@ describe('mquery', function() {
     });
 
     after(function(done) {
-      mquery(col).remove({ name: 'stream' }).exec(done);
+      mquery(col).deleteMany({ name: 'stream' }).exec(done);
     });
 
     describe('throws', function() {
       describe('if used with non-find operations', function() {
-        const ops = ['update', 'findOneAndUpdate', 'remove', 'count', 'distinct'];
+        const ops = ['update', 'findOneAndUpdate', 'count', 'distinct'];
 
         ops.forEach(function(op) {
           assert.throws(function() {

--- a/test/index.js
+++ b/test/index.js
@@ -2625,7 +2625,7 @@ describe('mquery', function() {
 
     describe('throws', function() {
       describe('if used with non-find operations', function() {
-        const ops = ['update', 'findOneAndUpdate', 'count', 'distinct'];
+        const ops = ['findOneAndUpdate', 'count', 'distinct'];
 
         ops.forEach(function(op) {
           assert.throws(function() {

--- a/test/index.js
+++ b/test/index.js
@@ -1216,7 +1216,6 @@ describe('mquery', function() {
   const negated = {
     limit: { distinct: false, count: true },
     skip: { distinct: false, count: true },
-    maxScan: { distinct: false, count: false },
     batchSize: { distinct: false, count: false },
     maxTime: { distinct: true, count: true, name: 'maxTimeMS' }
   };
@@ -1711,13 +1710,6 @@ describe('mquery', function() {
         done();
       });
 
-      it('maxScan', function(done) {
-        assert.throws(function() {
-          mquery().maxScan(300).count();
-        }, /maxScan cannot be used with count/);
-        done();
-      });
-
       it('snapshot', function(done) {
         assert.throws(function() {
           mquery().snapshot().count();
@@ -1886,13 +1878,6 @@ describe('mquery', function() {
         assert.throws(function() {
           mquery({}, { batchSize: 3 }).distinct();
         }, /batchSize cannot be used with distinct/);
-        done();
-      });
-
-      it('maxScan', function(done) {
-        assert.throws(function() {
-          mquery().maxScan(300).distinct();
-        }, /maxScan cannot be used with distinct/);
         done();
       });
 
@@ -2123,13 +2108,6 @@ describe('mquery', function() {
         assert.throws(function() {
           mquery({}, { batchSize: 3 })[method]();
         }, new RegExp('batchSize cannot be used with ' + method));
-        done();
-      });
-
-      it('maxScan', function(done) {
-        assert.throws(function() {
-          mquery().maxScan(300)[method]();
-        }, new RegExp('maxScan cannot be used with ' + method));
         done();
       });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1223,26 +1223,6 @@ describe('mquery', function() {
     simpleOption(key, negated[key]);
   });
 
-  describe('snapshot', function() {
-    it('works', function() {
-      let query;
-
-      query = mquery();
-      query.snapshot();
-      assert.equal(true, query.options.snapshot);
-
-      query = mquery();
-      query.snapshot(true);
-      assert.equal(true, query.options.snapshot);
-
-      query = mquery();
-      query.snapshot(false);
-      assert.equal(false, query.options.snapshot);
-    });
-    noDistinct('snapshot');
-    no('count', 'snapshot');
-  });
-
   describe('hint', function() {
     it('accepts an object', function() {
       const query2 = mquery();
@@ -1710,13 +1690,6 @@ describe('mquery', function() {
         done();
       });
 
-      it('snapshot', function(done) {
-        assert.throws(function() {
-          mquery().snapshot().count();
-        }, /snapshot cannot be used with count/);
-        done();
-      });
-
       it('tailable', function(done) {
         assert.throws(function() {
           mquery().tailable().count();
@@ -1878,13 +1851,6 @@ describe('mquery', function() {
         assert.throws(function() {
           mquery({}, { batchSize: 3 }).distinct();
         }, /batchSize cannot be used with distinct/);
-        done();
-      });
-
-      it('snapshot', function(done) {
-        assert.throws(function() {
-          mquery().snapshot().distinct();
-        }, /snapshot cannot be used with distinct/);
         done();
       });
 
@@ -2108,13 +2074,6 @@ describe('mquery', function() {
         assert.throws(function() {
           mquery({}, { batchSize: 3 })[method]();
         }, new RegExp('batchSize cannot be used with ' + method));
-        done();
-      });
-
-      it('snapshot', function(done) {
-        assert.throws(function() {
-          mquery().snapshot()[method]();
-        }, new RegExp('snapshot cannot be used with ' + method));
         done();
       });
 


### PR DESCRIPTION
**Summary**

This PR updates mquery to remove the functions / options that mongoose 7 will remove:
- `maxScan`
- `snapshot` (not the read-concern)
- `remove`
- `update`

re https://github.com/Automattic/mongoose/pull/12955#discussion_r1110387422

PS: weirdly, i have not seen any tests for `update`